### PR TITLE
Fix iOS

### DIFF
--- a/Modules/@babylonjs/react-native/ios/BabylonModule.mm
+++ b/Modules/@babylonjs/react-native/ios/BabylonModule.mm
@@ -25,4 +25,11 @@ RCT_EXPORT_METHOD(initialize:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseR
     });
 }
 
+RCT_EXPORT_METHOD(resetView:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [BabylonNativeInterop resetView];
+        resolve([NSNull null]);
+    });
+}
+
 @end

--- a/Modules/@babylonjs/react-native/ios/BabylonNativeInterop.h
+++ b/Modules/@babylonjs/react-native/ios/BabylonNativeInterop.h
@@ -6,5 +6,7 @@
 @interface BabylonNativeInterop : NSObject
 + (void)initialize:(RCTBridge*)bridge;
 + (void)updateView:(MTKView*)mtkView;
++ (void)renderView;
++ (void)resetView;
 + (void)reportTouchEvent:(MTKView*)mtkView touches:(NSSet<UITouch*>*)touches event:(UIEvent*)event;
 @end

--- a/Modules/@babylonjs/react-native/ios/BabylonNativeInterop.mm
+++ b/Modules/@babylonjs/react-native/ios/BabylonNativeInterop.mm
@@ -37,21 +37,6 @@ static NSMutableArray* activeTouches;
     } };
 
     Babylon::Initialize(*GetJSIRuntime(bridge), std::move(jsDispatcher));
-
-    [[NSNotificationCenter defaultCenter] removeObserver:self
-        name:RCTBridgeWillInvalidateModulesNotification
-        object:bridge.parentBridge];
-
-    [[NSNotificationCenter defaultCenter] addObserver:self
-        selector:@selector(onBridgeWillInvalidate:)
-        name:RCTBridgeWillInvalidateModulesNotification
-        object:bridge.parentBridge];
-}
-
-// NOTE: This happens during dev mode reload, when the JS engine is being shutdown and restarted.
-+ (void)onBridgeWillInvalidate:(NSNotification*)notification
-{
-    Babylon::Deinitialize();
 }
 
 + (void)updateView:(MTKView*)mtkView {
@@ -60,6 +45,14 @@ static NSMutableArray* activeTouches;
     if (width != 0 && height != 0) {
         Babylon::UpdateView((__bridge void*)mtkView, width, height);
     }
+}
+
++ (void)renderView {
+    Babylon::RenderView();
+}
+
++ (void)resetView {
+    Babylon::ResetView();
 }
 
 + (void)reportTouchEvent:(MTKView*)mtkView touches:(NSSet<UITouch*>*)touches event:(UIEvent*)event {

--- a/Modules/@babylonjs/react-native/ios/EngineViewManager.mm
+++ b/Modules/@babylonjs/react-native/ios/EngineViewManager.mm
@@ -50,6 +50,10 @@
     [BabylonNativeInterop reportTouchEvent:self touches:touches event:event];
 }
 
+- (void)drawRect:(CGRect)rect {
+    [BabylonNativeInterop renderView];
+}
+
 - (void)takeSnapshot {
     // We must take the screenshot on the main thread otherwise we might fail to get a valid handle on the view's image.
     dispatch_async(dispatch_get_main_queue(), ^{


### PR DESCRIPTION
This brings in Babylon Native fixes for iOS, and fixes iOS for Babylon React Native. These issues remain:
- Same issue as Android where when you exit XR, it takes some time for the regular view to show back up (but rotating the display does not fix it). I've found that the longer you stay in XR mode, the longer the pause is when exiting XR.
- Toggle EngineScreen crashes when toggling back on. Not sure if this is the same issue with calling into a disposed native engine (or wasn't there another issue where there was outstanding pending work or something?).
- Dev mode reload fails because JSC says there are outstanding objects.